### PR TITLE
Provider connect方法分离store代码

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,50 @@
-1.0 react-reduxdemo1 基础版本实现
+1.1 Provider组件与connect方法
+
+为了使react 和 redux进行结合 ，需要通过 react-redux 模块实现连接
+npm install react-redux --save
+--
+
+```
+connect 作用
+1. 帮助订阅store
+2. 当store中状态发生变化，  会重新渲染组件
+
+3. 获取store中的状态， 将状态映射到props属性中映射给组件
+4. 获取dispatch方法， 触发action 
+```
+
+
+connect方法两个参数意义
+mapStateToProps，
+mapDispatchToProps，
+
+``` jsx
+const mapStateToProps = (state)=>({
+    // a:'b',
+    count:state.count
+})
+
+
+
+const mapDispatchToProps = (dispatch)=>{
+  
+  return {
+    // 简化后如下
+    addCount(data) {
+      dispatch(increment)
+    },
+
+    minusCount(data) {
+      dispatch(decrement)
+    },
+
+
+    dispatch
+  }
+}
+
+
+export default connect(mapStateToProps,mapDispatchToProps )(Counter);
+
+
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -2317,6 +2317,15 @@
         "@types/node": "*"
       }
     },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmmirror.com/@types/hoist-non-react-statics/download/@types/hoist-non-react-statics-3.3.1.tgz?cache=0&sync_timestamp=1637265727153&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2F%40types%2Fhoist-non-react-statics%2Fdownload%2F%40types%2Fhoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha1-ESSq/lEYy1kZd66xzqrtEHDrA58=",
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmmirror.com/@types/html-minifier-terser/download/@types/html-minifier-terser-6.1.0.tgz",
@@ -2390,6 +2399,11 @@
       "resolved": "https://registry.npmmirror.com/@types/prettier/download/@types/prettier-2.4.2.tgz?cache=0&sync_timestamp=1637269803025&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2F%40types%2Fprettier%2Fdownload%2F%40types%2Fprettier-2.4.2.tgz",
       "integrity": "sha512-ekoj4qOQYp7CvjX8ZDBgN86w3MqQhLE1hczEJbEIjgFEumDy+na/4AJAbLXfgEWFNB2pKadM5rPFtuSGMWK7xA=="
     },
+    "@types/prop-types": {
+      "version": "15.7.4",
+      "resolved": "https://registry.npmmirror.com/@types/prop-types/download/@types/prop-types-15.7.4.tgz",
+      "integrity": "sha1-/PcgXCXf95Xuea8eMNosl5CAjxE="
+    },
     "@types/q": {
       "version": "1.5.5",
       "resolved": "https://registry.npmmirror.com/@types/q/download/@types/q-1.5.5.tgz?cache=0&sync_timestamp=1637269733784&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2F%40types%2Fq%2Fdownload%2F%40types%2Fq-1.5.5.tgz",
@@ -2405,6 +2419,27 @@
       "resolved": "https://registry.npmmirror.com/@types/range-parser/download/@types/range-parser-1.2.4.tgz?cache=0&sync_timestamp=1637268455466&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2F%40types%2Frange-parser%2Fdownload%2F%40types%2Frange-parser-1.2.4.tgz",
       "integrity": "sha1-zWZ7z90CUhOq+3ylkVqTJZCs3Nw="
     },
+    "@types/react": {
+      "version": "17.0.38",
+      "resolved": "https://registry.npmmirror.com/@types/react/download/@types/react-17.0.38.tgz",
+      "integrity": "sha512-SI92X1IA+FMnP3qM5m4QReluXzhcmovhZnLNm3pyeQlooi02qI7sLiepEYqT678uNiyc25XfCqxREFpy3W7YhQ==",
+      "requires": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "@types/react-redux": {
+      "version": "7.1.21",
+      "resolved": "https://registry.npmmirror.com/@types/react-redux/download/@types/react-redux-7.1.21.tgz",
+      "integrity": "sha512-bLdglUiBSQNzWVVbmNPKGYYjrzp3/YDPwfOH3nLEz99I4awLlaRAPWjo6bZ2POpxztFWtDDXIPxBLVykXqBt+w==",
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
+      }
+    },
     "@types/resolve": {
       "version": "1.17.1",
       "resolved": "https://registry.npmmirror.com/@types/resolve/download/@types/resolve-1.17.1.tgz?cache=0&sync_timestamp=1637269963703&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2F%40types%2Fresolve%2Fdownload%2F%40types%2Fresolve-1.17.1.tgz",
@@ -2417,6 +2452,11 @@
       "version": "0.12.1",
       "resolved": "https://registry.npmmirror.com/@types/retry/download/@types/retry-0.12.1.tgz?cache=0&sync_timestamp=1637270516824&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2F%40types%2Fretry%2Fdownload%2F%40types%2Fretry-0.12.1.tgz",
       "integrity": "sha1-2PHA0Nwjr61twWqemToIZXdLQGU="
+    },
+    "@types/scheduler": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmmirror.com/@types/scheduler/download/@types/scheduler-0.16.2.tgz?cache=0&sync_timestamp=1637270013832&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2F%40types%2Fscheduler%2Fdownload%2F%40types%2Fscheduler-0.16.2.tgz",
+      "integrity": "sha1-GmL4lSVyPd4kuhsBsJK/XfitTTk="
     },
     "@types/serve-index": {
       "version": "1.9.1",
@@ -4062,6 +4102,11 @@
         }
       }
     },
+    "csstype": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmmirror.com/csstype/download/csstype-3.0.10.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Fcsstype%2Fdownload%2Fcsstype-3.0.10.tgz",
+      "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
+    },
     "damerau-levenshtein": {
       "version": "1.0.7",
       "resolved": "https://registry.nlark.com/damerau-levenshtein/download/damerau-levenshtein-1.0.7.tgz",
@@ -5648,6 +5693,14 @@
       "version": "1.2.0",
       "resolved": "https://registry.npm.taobao.org/he/download/he-1.2.0.tgz",
       "integrity": "sha1-hK5l+n6vsWX922FWauFLrwVmTw8="
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.nlark.com/hoist-non-react-statics/download/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha1-7OCsr3HWLClpwuxZ/v9CpLGoW0U=",
+      "requires": {
+        "react-is": "^16.7.0"
+      }
     },
     "hoopy": {
       "version": "0.1.4",
@@ -9364,6 +9417,26 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmmirror.com/react-is/download/react-is-16.13.1.tgz",
       "integrity": "sha1-eJcppNw23imZ3BVt1sHZwYzqVqQ="
+    },
+    "react-redux": {
+      "version": "7.2.6",
+      "resolved": "https://registry.npmmirror.com/react-redux/download/react-redux-7.2.6.tgz",
+      "integrity": "sha1-SWM6JP5VK1+cr1j+uKE4k23f6ao=",
+      "requires": {
+        "@babel/runtime": "^7.15.4",
+        "@types/react-redux": "^7.1.20",
+        "hoist-non-react-statics": "^3.3.2",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^17.0.2"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmmirror.com/react-is/download/react-is-17.0.2.tgz",
+          "integrity": "sha1-5pHUqOnHiTZWVVOas3J2Kw77VPA="
+        }
+      }
     },
     "react-refresh": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/user-event": "^13.5.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-redux": "^7.2.6",
     "react-scripts": "5.0.0",
     "redux": "^4.1.2",
     "web-vitals": "^2.1.2"

--- a/src/components/Counter/index.js
+++ b/src/components/Counter/index.js
@@ -1,0 +1,68 @@
+import React from "react";
+import { connect } from "react-redux";
+import {increment, decrement} from './../../index'
+
+// function Counter(props) {
+// 解构操作
+function Counter({count, addCount, minusCount, dispatch}) {
+  console.log(count);
+  
+  return (
+    <div>
+      {/* <button onClick={() => store.dispatch(increment)}>+</button> */}
+      {/* <button onClick={() => dispatch(increment)}>+</button> */}
+      {/* <button onClick={() => addCount()}>+</button> */}
+      <button onClick={addCount}>+</button>
+      {/* <span>{store.getState().count}</span> */}
+      <span>{count}</span>
+      {/* <button onClick={() => store.dispatch(decrement)}>-</button> */}
+      {/* <button onClick={() => minusCount()}>-</button> */}
+      <button onClick={minusCount}>-</button>
+    </div>
+  );
+}
+
+
+const mapStateToProps = (state)=>{
+  return {
+    // a:'b',
+    count:state.count
+  }
+}
+
+
+
+const mapDispatchToProps = (dispatch)=>{
+  
+  return {
+    // addCount:function (data) {
+    //   dispatch(increment)
+    // },
+
+    // 简化后如下
+    addCount(data) {
+      dispatch(increment)
+    },
+
+    minusCount(data) {
+      dispatch(decrement)
+    },
+
+
+    dispatch
+  }
+}
+
+
+export default connect(mapStateToProps,mapDispatchToProps )(Counter);
+/* 
+  
+connect 作用
+1. 帮助订阅store
+2. 当store中状态发生变化，  会重新渲染组件
+
+3. 获取store中的状态， 将状态映射到props属性中映射给组件
+4. 获取dispatch方法， 触发action 
+
+
+  */

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,16 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import App from "./App";
+// import App from "./App";
+import Counter from "./components/Counter";
 
 import { createStore } from "redux";
+import { Provider } from "react-redux";
 
+/* 
+react-redux 
+  Provider: 将store放到全局中，  组件都能拿到的地方
+  connect
+*/
 const initialState = {
   count: 0,
 };
@@ -12,42 +19,35 @@ function reducer(state = initialState, actions) {
   switch (actions.type) {
     case "increment": // 数值 + 1 ,返回一个新对象
       return {
-        count: state.count + 1
-      }
+        count: state.count + 1,
+      };
 
     case "decrement":
       return {
-        count: state.count - 1
-      }
+        count: state.count - 1,
+      };
     default:
       return state;
   }
-
-
 }
 
-const increment = { type: "increment" };
-const decrement = { type: "decrement" };
+export const increment = { type: "increment" };
+export const decrement = { type: "decrement" };
 
 const store = createStore(reducer);
 
-function Counter() {
-  return (
-    <div>
-      <button onClick={() => store.dispatch(increment)}>+</button>
-      <span>{store.getState().count}</span>
-      <button onClick={() => store.dispatch(decrement)}>-</button>
-    </div>
-  );
-}
-
-// 必须要订阅订阅数据更新,返回一个新的组件
-store.subscribe(()=>{// 订阅数据返回新的数值
-  ReactDOM.render(<Counter />, document.getElementById("root"));
-})
-
-
+// 有了Provider后，  就不需要手动subscribe订阅了
+// store.subscribe(() => {
+//   // 订阅数据返回新的数值
+//   ReactDOM.render(<Counter />, document.getElementById("root"));
+// });
 
 // console.log("store", store.getState());
 
-ReactDOM.render(<Counter />, document.getElementById("root"));
+ReactDOM.render(
+  // 通过Provider 组件， 将store 放到了全局组件可以够得到的地方
+  <Provider store={store}>
+    <Counter />
+  </Provider>,
+  document.getElementById("root")
+);


### PR DESCRIPTION
1.1 Provider组件与connect方法

为了使react 和 redux进行结合 ，需要通过 react-redux 模块实现连接
npm install react-redux --save
--

```
connect 作用
1. 帮助订阅store
2. 当store中状态发生变化，  会重新渲染组件

3. 获取store中的状态， 将状态映射到props属性中映射给组件
4. 获取dispatch方法， 触发action 
```


connect方法两个参数意义
mapStateToProps，
mapDispatchToProps，

``` jsx
const mapStateToProps = (state)=>({
    // a:'b',
    count:state.count
})



const mapDispatchToProps = (dispatch)=>{
  
  return {
    // 简化后如下
    addCount(data) {
      dispatch(increment)
    },

    minusCount(data) {
      dispatch(decrement)
    },


    dispatch
  }
}


export default connect(mapStateToProps,mapDispatchToProps )(Counter);


```